### PR TITLE
Switch LinearSolve indexing to 32-bit

### DIFF
--- a/src/table_gen/linear_solve.cc
+++ b/src/table_gen/linear_solve.cc
@@ -26,18 +26,18 @@ static double const kMaxIterations = 100000;
 static double const kTol = 1e-30;
 
 void LinearSolve(std::vector<double> const &Am,
-                 std::vector<size_t> const &row_indexes,
-                 std::vector<size_t> const &col_indexes,
+                 std::vector<uint32_t> const &row_indexes,
+                 std::vector<uint32_t> const &col_indexes,
                  std::vector<double> const &bv,
                  std::vector<double> &x_solution) {
-  size_t n = bv.size();
-  size_t len_Am = Am.size();
+  uint32_t n = static_cast<uint32_t>(bv.size());
+  uint32_t len_Am = static_cast<uint32_t>(Am.size());
 
   std::vector<double> x_solution_old(n, 0.0);
 
-  for (uint64_t i = 0; i < kMaxIterations; ++i) {
-    uint64_t entry = 0;
-    for (uint64_t j = 0; j < n; ++j) {
+  for (uint32_t i = 0; i < static_cast<uint32_t>(kMaxIterations); ++i) {
+    uint32_t entry = 0;
+    for (uint32_t j = 0; j < n; ++j) {
       double r = 0;
       double s = 0;
       while (entry < len_Am && row_indexes[entry] == j) {
@@ -52,7 +52,7 @@ void LinearSolve(std::vector<double> const &Am,
     }
 
     double norm = 0;
-    for (uint64_t j = 0; j < n; ++j) {
+    for (uint32_t j = 0; j < n; ++j) {
       norm = std::max(norm, std::abs(x_solution[j] - x_solution_old[j]));
     }
 

--- a/src/table_gen/linear_solve.h
+++ b/src/table_gen/linear_solve.h
@@ -18,6 +18,7 @@
 #define LDHELMET_TABLE_GEN_LINEAR_SOLVE_H_
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include <vector>
 
@@ -32,8 +33,8 @@
 // n is the number of rows/columns in Am and bv.
 // len_Am is the number of entries in Am.
 void LinearSolve(std::vector<double> const &Am,
-                 std::vector<size_t> const &row_indexes,
-                 std::vector<size_t> const &col_indexes,
+                 std::vector<uint32_t> const &row_indexes,
+                 std::vector<uint32_t> const &col_indexes,
                  std::vector<double> const &bv,
                  std::vector<double> &x_solution);
 

--- a/src/table_gen/solve_scc.cc
+++ b/src/table_gen/solve_scc.cc
@@ -166,14 +166,14 @@ void AdjustAm(IndexTables const &index_tables,
               double coeff,
               Conf const &tmp_conf,
               std::vector<double> &Am,
-              std::vector<size_t> &row_indexes,
-              std::vector<size_t> &col_indexes) {
+              std::vector<uint32_t> &row_indexes,
+              std::vector<uint32_t> &col_indexes) {
   // Conf to column index.
   size_t tmp_conf_index = ConfToIndex(index_tables, tmp_conf);
 
   Am.push_back(-1.0 * (coeff / denominator));
-  row_indexes[Am.size() - 1] = conf_index;
-  col_indexes[Am.size() - 1] = tmp_conf_index;
+  row_indexes[Am.size() - 1] = static_cast<uint32_t>(conf_index);
+  col_indexes[Am.size() - 1] = static_cast<uint32_t>(tmp_conf_index);
 }
 
 void ConstructSystem(Vec8 const &table,
@@ -185,8 +185,8 @@ void ConstructSystem(Vec8 const &table,
                      uint32_t b_mar,
                      uint32_t B_mar,
                      std::vector<double> &Am,
-                     std::vector<size_t> &row_indexes,
-                     std::vector<size_t> &col_indexes,
+                     std::vector<uint32_t> &row_indexes,
+                     std::vector<uint32_t> &col_indexes,
                      std::vector<double> &bv) {
   Conf conf;
   uint32_t min_ab = std::min(a_mar, b_mar);
@@ -636,8 +636,8 @@ void ConstructSystem(Vec8 const &table,
           }
 
           Am.push_back(1.0);
-          col_indexes[Am.size() - 1] = conf_index;
-          row_indexes[Am.size() - 1] = conf_index;
+          col_indexes[Am.size() - 1] = static_cast<uint32_t>(conf_index);
+          row_indexes[Am.size() - 1] = static_cast<uint32_t>(conf_index);
         }
       }
     }
@@ -666,8 +666,8 @@ void SolveSCC(Vec8 *table,
   std::vector<double> Am;
   Am.reserve(9 * num_confs_scc);
 
-  std::vector<size_t> row_indexes(9 * num_confs_scc, 0.0);
-  std::vector<size_t> col_indexes(9 * num_confs_scc, 0.0);
+  std::vector<uint32_t> row_indexes(9 * num_confs_scc, 0);
+  std::vector<uint32_t> col_indexes(9 * num_confs_scc, 0);
   std::vector<double> bv(num_confs_scc);
 
   ConstructSystem(*table,

--- a/src/table_gen/solve_scc.h
+++ b/src/table_gen/solve_scc.h
@@ -73,8 +73,8 @@ void AdjustAm(IndexTables const &index_tables,
               double coeff,
               Conf const &tmp_conf,
               std::vector<double> &Am,
-              std::vector<size_t> &row_indexes,
-              std::vector<size_t> &col_indexes);
+              std::vector<uint32_t> &row_indexes,
+              std::vector<uint32_t> &col_indexes);
 
 // Set up system of linear equations for a given configuration.
 void ConstructSystem(Vec8 const &table,
@@ -86,8 +86,8 @@ void ConstructSystem(Vec8 const &table,
                      uint32_t b_mar,
                      uint32_t B_mar,
                      std::vector<double> &Am,
-                     std::vector<size_t> &row_indexes,
-                     std::vector<size_t> &col_indexes,
+                     std::vector<uint32_t> &row_indexes,
+                     std::vector<uint32_t> &col_indexes,
                      std::vector<double> &bv);
 
 // Solve SCC for inductive case.


### PR DESCRIPTION
## Summary
- use `uint32_t` for row/col indexes in linear solver
- update `LinearSolve` interface
- adjust solve_scc to use the new types
- iterate using 32‑bit indices inside `LinearSolve`

## Testing
- `make` *(fails: boost headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e02a4b98832f8d8d4801681913e9