### PR TITLE
Use flat vector storage for two-locus tables

### DIFF
--- a/src/common/vector_definitions.h
+++ b/src/common/vector_definitions.h
@@ -26,6 +26,9 @@ typedef std::vector<Vec3>   Vec4;
 typedef std::vector<Vec4>   Vec5;
 typedef std::vector<Vec5>   Vec6;
 typedef std::vector<Vec6>   Vec7;
-typedef std::vector<Vec7>   Vec8;
+// Vec8 previously represented an eight-level nested vector for storing table
+// values.  The table code now stores a flat vector of doubles for each degree,
+// so Vec8 becomes a vector of vectors of doubles.
+typedef std::vector<std::vector<double> > Vec8;
 
 #endif  // LDHELMET_COMMON_VECTOR_DEFINITIONS_H_

--- a/src/table_gen/solve_degree-inl.h
+++ b/src/table_gen/solve_degree-inl.h
@@ -201,7 +201,7 @@ void SolveDegree(double theta,
   // Free memory in table for degree - 2, which is no longer needed by
   // subsequent degrees.
   if (degree >= 4) {
-    Vec7().swap((*table)[degree - 2]);
+    std::vector<double>().swap((*table)[degree - 2]);
   }
 }
 

--- a/src/table_gen/table_management.cc
+++ b/src/table_gen/table_management.cc
@@ -12,68 +12,52 @@
 //
 // <http://www.gnu.org/licenses/>
 //
-// 
+//
 
 #include "table_gen/table_management.h"
 
 #include <stdint.h>
-
 #include <algorithm>
 
 #include "common/conf.h"
 #include "common/vector_definitions.h"
+#include "table_gen/solve_scc.h"
 
-uint64_t AllocateMemoryToTable(Vec8 *table, uint32_t degree) {
-  // Allocate memory to table for this degree.
-  // table[degree][a_mar][A_mar][b_mar][ab][aB][Ab][AB]
-  uint64_t num_confs = 0;
-  // Size is degree + 1 for index a_mar.
-  (*table)[degree] = Vec7(degree + 1, Vec6());
-  for (uint32_t a_mar = 0; a_mar <= degree; ++a_mar) {
-    // Size is degree - a_mar + 1 for index A_mar.
-    (*table)[degree][a_mar].resize(degree - a_mar + 1);
-    uint32_t A_mar_max = degree - a_mar;
-    for (uint32_t A_mar = 0; A_mar <= A_mar_max; ++A_mar) {
-      // Size is degree-a_mar-A_mar+1 for index b_mar.
-      (*table)[degree][a_mar][A_mar].resize(degree - a_mar - A_mar + 1);
-      // Restrict b_mar to be less than or equal to a_mar to maintain
-      // canonical form.
-      uint32_t b_mar_max = std::min(degree - a_mar - A_mar, a_mar);
-      for (uint32_t b_mar = 0; b_mar <= b_mar_max; ++b_mar) {
-        uint32_t B_mar = degree - a_mar - A_mar - b_mar;
-        // Skip this SCC because we want (a_mar, A_mar) >= (b_mar, B_mar)
-        // (in lexicographic order).
-        if (b_mar == a_mar && B_mar > A_mar) {
+namespace {
+
+// Compute the flat index of a configuration in the contiguous table.
+size_t ConfIndex(Conf const& in_conf) {
+  Conf conf = GetCanon(in_conf);
+  uint32_t a_mar = conf.a_ + conf.ab_ + conf.aB_;
+  uint32_t A_mar = conf.A_ + conf.Ab_ + conf.AB_;
+  uint32_t b_mar = conf.b_ + conf.ab_ + conf.Ab_;
+  uint32_t B_mar = conf.B_ + conf.aB_ + conf.AB_;
+  uint32_t degree = a_mar + A_mar + b_mar + B_mar;
+
+  size_t offset = 0;
+  for (uint32_t a = 0; a <= degree; ++a) {
+    for (uint32_t A = 0; A <= degree - a; ++A) {
+      for (uint32_t b = 0; b <= std::min(degree - a - A, a); ++b) {
+        uint32_t B = degree - a - A - b;
+        if (b == a && B > A) {
           continue;
         }
-
-        // At this point, a_mar, A_mar, b_mar, and B_mar are fixed.
-        // Enumerate all configurations consistent with this SCC.
-        uint32_t min_ab = std::min(a_mar, b_mar);
-
-        // Size min(a_mar,b_mar)+1 for index ab.
-        (*table)[degree][a_mar][A_mar][b_mar].resize(min_ab + 1);
-        for (uint32_t ab = 0; ab <= min_ab; ++ab) {
-          uint32_t min_aB = std::min(a_mar - ab, B_mar);
-          // Size is min(a_mar - ab, B_mar) + 1 for index aB.
-          (*table)[degree][a_mar][A_mar][b_mar][ab].resize(min_aB + 1);
-          for (uint32_t aB = 0; aB <= min_aB; ++aB) {
-            uint32_t min_Ab = std::min(b_mar - ab, A_mar);
-            // Size is min(min(b_mar - ab, A_mar)+1, aB) for index Ab
-            // (with symmetry optimization).
-            (*table)[degree][a_mar][A_mar][b_mar][ab][aB].resize(min_Ab + 1);
-            for (uint32_t Ab = 0; Ab <= min_Ab; ++Ab) {
-              uint32_t min_AB = std::min(A_mar - Ab, B_mar - aB);
-              // Size is min(A_mar-Ab,B_mar-aB)+1 for index AB.
-              (*table)[degree][a_mar][A_mar]
-                              [b_mar][ab][aB][Ab].resize(min_AB + 1);
-              num_confs += min_AB + 1;
-            }
-          }
+        if (a == a_mar && A == A_mar && b == b_mar && B == B_mar) {
+          IndexTables tables = ComputeIndexTables(a_mar, A_mar, b_mar, B_mar);
+          return offset + ConfToIndex(tables, conf);
         }
+        offset += ComputeNumConfsSCC(a, A, b, B);
       }
     }
   }
+  return offset;  // should never reach here
+}
+
+}  // namespace
+
+uint64_t AllocateMemoryToTable(Vec8 *table, uint32_t degree) {
+  uint64_t num_confs = ComputeNumConfs(degree);
+  (*table)[degree] = std::vector<double>(num_confs, 0.0);
   return num_confs;
 }
 
@@ -90,16 +74,17 @@ Conf GetCanon(Conf conf) {
   return conf;
 }
 
+void SetTable(Vec8 *table, Conf const &in_conf, double value) {
+  Conf conf = GetCanon(in_conf);
+  uint32_t degree = conf.ComputeDegree();
+  size_t index = ConfIndex(conf);
+  (*table)[degree][index] = value;
+}
+
 double GetTable(Vec8 const &table, Conf const &in_conf) {
   Conf conf = GetCanon(in_conf);
-  uint32_t a_mar = conf.a_ + conf.ab_ + conf.aB_;
-  uint32_t A_mar = conf.A_ + conf.Ab_ + conf.AB_;
-  uint32_t b_mar = conf.b_ + conf.ab_ + conf.Ab_;
-  uint32_t B_mar = conf.B_ + conf.aB_ + conf.AB_;
-  uint32_t degree = a_mar + A_mar + b_mar + B_mar;
-
-  assert(a_mar + A_mar > 0 && b_mar + B_mar > 0);
-
-  return table[degree][a_mar][A_mar][b_mar]
-              [conf.ab_][conf.aB_][conf.Ab_][conf.AB_];
+  uint32_t degree = conf.ComputeDegree();
+  size_t index = ConfIndex(conf);
+  return table[degree][index];
 }
+

--- a/src/table_gen/table_management.h
+++ b/src/table_gen/table_management.h
@@ -24,23 +24,13 @@
 
 // Allocate memory to table.
 // Allocates memory to invalid configurations as well, and initializes them to
-// 0.0.
+// 0.0.  Returns the number of configurations allocated for the degree.
 uint64_t AllocateMemoryToTable(Vec8 *table, uint32_t degree);
 
 Conf GetCanon(Conf conf);
 
 // Set the probability of the given configuration in the table.
-inline void SetTable(Vec8 *table, Conf const &in_conf, double value) {
-  Conf conf = GetCanon(in_conf);
-  uint32_t a_mar = conf.a_ + conf.ab_ + conf.aB_;
-  uint32_t A_mar = conf.A_ + conf.Ab_ + conf.AB_;
-  uint32_t b_mar = conf.b_ + conf.ab_ + conf.Ab_;
-  uint32_t B_mar = conf.B_ + conf.aB_ + conf.AB_;
-  uint32_t degree = a_mar + A_mar + b_mar + B_mar;
-  (*table)[degree][a_mar][A_mar][b_mar]
-          [conf.ab_][conf.aB_][conf.Ab_][conf.AB_] = value;
-  return;
-}
+void SetTable(Vec8 *table, Conf const &in_conf, double value);
 
 // Get the probability of the given configuration from table.
 // table also contains entries for invalid configurations.


### PR DESCRIPTION
## Summary
- store each degree of the LDhelmet table in a contiguous `std::vector<double>`
- compute offsets for configurations using a new `ConfIndex` helper
- adapt memory freeing to work with the new structure

## Testing
- `make table_gen` *(fails: boost headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865e15c4304832f9ee6c39a567d0d12